### PR TITLE
회원 탈퇴 시 사용자 관련 데이터도 함께 삭제하도록 수정

### DIFF
--- a/src/main/java/com/example/newsfeed/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/newsfeed/comment/repository/CommentRepository.java
@@ -4,9 +4,24 @@ import com.example.newsfeed.comment.domain.Comment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     Page<Comment> findAllByPostId(Long postId, Pageable pageable);
     Comment findByUserId(Long userId);
     Comment findByPostId(Long postId);
+
+    @Modifying
+    @Query("UPDATE Comment c SET c.deletedAt = CURRENT_TIMESTAMP WHERE c.user.id = :userId AND c.deletedAt IS NULL")
+    void softDeleteByUserId(@Param("userId") Long userId);
+
+    @Modifying
+    @Query(value = "UPDATE comments c " +
+            "JOIN posts p ON c.post_id = p.id " +
+            "SET c.deleted_at = CURRENT_TIMESTAMP " +
+            "WHERE p.user_id = :postOwnerId AND c.deleted_at IS NULL",
+    nativeQuery = true)
+    void softDeleteByPostOwnerId(@Param("postOwnerId") Long postOwnerId);
 }

--- a/src/main/java/com/example/newsfeed/follow/repository/FollowRepository.java
+++ b/src/main/java/com/example/newsfeed/follow/repository/FollowRepository.java
@@ -5,6 +5,7 @@ import com.example.newsfeed.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -23,4 +24,10 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     @Query("SELECT f FROM Follow f JOIN FETCH f.follower WHERE f.followed = :user")
     Page<Follow> findAllByFollowed(@Param("user")User user, Pageable pageable);
+
+    @Modifying
+    @Query("UPDATE Follow f " +
+            "SET f.deletedAt = CURRENT_TIMESTAMP " +
+            "WHERE (f.followed.id = :userId OR f.follower.id = :userId) AND f.deletedAt IS NULL")
+    void softDeleteFollowsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/newsfeed/post/repository/PostRepository.java
+++ b/src/main/java/com/example/newsfeed/post/repository/PostRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -21,4 +22,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "ORDER BY p.createdAt DESC"
     )
     Page<Post> findAllByFollowing(@Param("user") User user, Pageable pageable);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.deletedAt = CURRENT_TIMESTAMP WHERE p.user.id = :userId AND p.deletedAt IS NULL")
+    void softDeleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/newsfeed/user/domain/User.java
+++ b/src/main/java/com/example/newsfeed/user/domain/User.java
@@ -11,7 +11,7 @@ import org.hibernate.annotations.SQLRestriction;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("deleted_at IS NULL")
-@SQLDelete(sql = "UPDATE users SET deleted_at = NOW() WHERE id = ?")
+@SQLDelete(sql = "UPDATE users SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 public class User extends BaseTimeEntity {
 
     @Id


### PR DESCRIPTION
### 세부 사항
회원 탈퇴 시 사용자 관련 데이터 함께 삭제

- 삭제되는 데이터: 사용자가 작성한 게시글, 사용자가 작성한 게시글의 댓글, 사용자가 작성한 댓글, 사용자와 연관된 팔로우 관계
- 삭제 방법: soft delete