### PR TITLE
게시글 조회 시 댓글 수 정보 추가 구현

### DIFF
--- a/newsfeed.sql
+++ b/newsfeed.sql
@@ -14,6 +14,7 @@ CREATE TABLE posts (
     user_id     BIGINT NOT NULL,
     title    VARCHAR(100) NOT NULL,
     content   TEXT NOT NULL,
+    comment_count INT UNSIGNED NOT NULL DEFAULT 0,
     created_at  DATETIME NOT NULL,
     updated_at  DATETIME NOT NULL,
     deleted_at DATETIME DEFAULT NULL,

--- a/src/main/java/com/example/newsfeed/post/domain/Post.java
+++ b/src/main/java/com/example/newsfeed/post/domain/Post.java
@@ -7,11 +7,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "posts")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
 public class Post extends BaseTimeEntity {
 
     @Id
@@ -27,6 +29,8 @@ public class Post extends BaseTimeEntity {
 
     private String content;
 
+    private int commentCount = 0;
+
     @Builder
     public Post(User user, String title, String content) {
         this.user = user;
@@ -37,5 +41,15 @@ public class Post extends BaseTimeEntity {
     public void update(String title, String content) {
         this.title = title;
         this.content = content;
+    }
+
+    public void incrementCommentCount() {
+        this.commentCount++;
+    }
+
+    public void decrementCommentCount() {
+        if(this.commentCount > 0) {
+            this.commentCount--;
+        }
     }
 }

--- a/src/main/java/com/example/newsfeed/post/dto/PostResponse.java
+++ b/src/main/java/com/example/newsfeed/post/dto/PostResponse.java
@@ -14,6 +14,7 @@ public class PostResponse {
     private String title;
     private String content;
     private String userName;
+    private int commentCount;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -23,6 +24,7 @@ public class PostResponse {
                 .title(post.getTitle())
                 .content(post.getContent())
                 .userName(post.getUser().getName())
+                .commentCount(post.getCommentCount())
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();


### PR DESCRIPTION
## 상세 내용
- posts 테이블에 comment_count 컬럼이 추가되었습니다.
  - 프로젝트 성격 상 Post 조회가 핵심 기능
  - Post 조회 시 매번 Join 연산을 하는 것보다 컬럼을 하나 추가하는 것이 좋겠다는 판단하에 컬럼을 추가합니다.
  - posts 테이블에 컬럼을 두고, 댓글을 추가/삭제할 때마다 +1, -1 수행 필요
- Post 엔티티에 commentCount 필드가 추가되었습니다.
- PostResponse에 commentCount(댓글 수) 정보가 추가되었습니다.